### PR TITLE
Add nonsustainable way to fix z-index in modal dropdowns

### DIFF
--- a/app/styles/component.modal.scss
+++ b/app/styles/component.modal.scss
@@ -4,15 +4,15 @@
  ========================================================================== */
 
 .modal-dialog {
-	z-index: 1005;
+  z-index: 1005;
 }
 
 /* small modal
  ========================================================================== */
 
 .modal-dialog.modal-dialog--small {
-	width: 35rem;
-	padding: 2rem 2rem 2.2rem;
+  width: 35rem;
+  padding: 2rem 2rem 2.2rem;
 }
 
 // TODO: put in styleguide
@@ -21,120 +21,125 @@
  ========================================================================== */
 
 .modal-overlay {
-	position: absolute;
-	left: 0;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	z-index: 1010;
-	background-color: rgba($white, 0.8);
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1010;
+  background-color: rgba($white, 0.8);
 }
 
 .modal-dialog.modal-dialog--wide {
-	width: 90vw;
-	max-width: none;
+  width: 90vw;
+  max-width: none;
 
-	&.modal-dialog--sectioned .modal-dialog__content > *{
-		max-height: 60vh;
-	}
+  &.modal-dialog--sectioned .modal-dialog__content > *{
+    max-height: 60vh;
+  }
 }
 
 .modal-overlay-hidden {
-	display: none !important;
+  display: none !important;
 }
 
 .modal-overlay__toggle {
-	position: absolute;
-	left: 0;
-	top: 0;
-	right: 0;
-	bottom: 0;
-	z-index: 1000;
+  position: absolute;
+  left: 0;
+  top: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 1000;
 }
 
 
-	/* full-width-modal remove once webuniversum updated*/
 
-	.modal-dialog.modal-dialog--full {
-		max-width: 100vw;
-		width: 100vw;
-		max-height: 100vh;
-		height: 100vh;
+.ember-power-select-dropdown.ember-basic-dropdown-content {
+  z-index: 1006;  /* this z-index needs to be fixed in a sustainable matter in the future *
+}
 
-		.modal-dialog__header {
-			height: 10vh;
-			max-height: none;
-			min-height: 6rem;
-		}
+  /* full-width-modal remove once webuniversum updated */
 
-		&.modal-dialog--sectioned .modal-dialog__content--sectioned > * {
-			max-height: 75vh;
-		}
-	}
+  .modal-dialog.modal-dialog--full {
+    max-width: 100vw;
+    width: 100vw;
+    max-height: 100vh;
+    height: 100vh;
+
+    .modal-dialog__header {
+      height: 10vh;
+      max-height: none;
+      min-height: 6rem;
+    }
+
+    &.modal-dialog--sectioned .modal-dialog__content--sectioned > * {
+      max-height: 75vh;
+    }
+  }
 
 /* Sectioned modal
  ========================================================================== */
 
 .modal-dialog.modal-dialog--sectioned {
-	padding: 0;
-	overflow: hidden;
-	max-height: none;
+  padding: 0;
+  overflow: hidden;
+  max-height: none;
 
-	.modal-dialog__header {
-		padding: 1.5rem 1.5rem 1rem 2rem;
+  .modal-dialog__header {
+    padding: 1.5rem 1.5rem 1rem 2rem;
 
-		.h1,
-		.h2,
-		.h3,
-		.h4,
-		.h5,
-		.h6 {
-			margin-bottom: 0;
-		}
-	}
+    .h1,
+    .h2,
+    .h3,
+    .h4,
+    .h5,
+    .h6 {
+      margin-bottom: 0;
+    }
+  }
 
-	.modal-dialog__content {
-		border-top: 1px solid $blue-gray-light;
-		padding: 1.5rem;
-		max-height: 25rem;
-		overflow: auto;
-	}
+  .modal-dialog__content {
+    border-top: 1px solid $blue-gray-light;
+    padding: 1.5rem;
+    max-height: 25rem;
+    overflow: auto;
+  }
 
-	.modal-dialog__content.modal-dialog__content--sectioned {
-		padding: 0;
-		max-height: none;
-	}
+  .modal-dialog__content.modal-dialog__content--sectioned {
+    padding: 0;
+    max-height: none;
+  }
 
-	.modal-dialog__footer {
-		padding: 1.5rem 1.5rem 2.5rem;
-		border-top: 1px solid $blue-gray-light;
-	}
+  .modal-dialog__footer {
+    padding: 1.5rem 1.5rem 2.5rem;
+    border-top: 1px solid $blue-gray-light;
+  }
 
-	button.button,
-	a.button {
-		margin-bottom: 0;
-	}
+  button.button,
+  a.button {
+    margin-bottom: 0;
+  }
 }
 
 .modal-dialog--sectioned .pager {
-	background-color: $blue-gray-lighter;
-	padding: 0.5rem 0;
+  background-color: $blue-gray-lighter;
+  padding: 0.5rem 0;
 }
 
 .modal-dialog,
 .modal-dialog.modal-dialog--sectioned {
 
-	@include for-phone-only {
-		height: auto;
-		max-height: calc(100vh - 2rem);
-		max-width: calc(100vw - 2rem);
+  @include for-phone-only {
+    height: auto;
+    max-height: calc(100vh - 2rem);
+    max-width: calc(100vw - 2rem);
 
-		.modal-dialog__content {
-			max-height: calc(100vh - 20rem);
-			height: auto;
-			min-height: none;
-		}
-	}
+    .modal-dialog__content {
+      max-height: calc(100vh - 20rem);
+      height: auto;
+      min-height: none;
+    }
+  }
 }
 
 
@@ -156,15 +161,15 @@
 
 
 .modal-dialog ul.preview-list {
-	min-height: 30rem;
-	overflow-y: auto;
-	overflow-x: none;
-	padding: 3rem 1.5rem;
+  min-height: 30rem;
+  overflow-y: auto;
+  overflow-x: none;
+  padding: 3rem 1.5rem;
 }
 
 .modal-dialog__content--sectioned > * {
-	max-height: 20rem;
-	overflow: auto;
+  max-height: 20rem;
+  overflow: auto;
 }
 
 .modal-dialog__content li.link-list__item {
@@ -172,7 +177,7 @@
   padding: 0;
 
   &:last-child {
-  	border-bottom: none;
+    border-bottom: none;
   }
 }
 
@@ -182,6 +187,6 @@
   text-decoration: none;
 
   &:hover {
-  	background-color: $blue-gray-lightest;
+    background-color: $blue-gray-lightest;
   }
 }

--- a/app/styles/component.modal.scss
+++ b/app/styles/component.modal.scss
@@ -55,7 +55,7 @@
 
 
 .ember-power-select-dropdown.ember-basic-dropdown-content {
-  z-index: 1006;  /* this z-index needs to be fixed in a sustainable matter in the future *
+  z-index: 1006;  /* this z-index needs to be fixed in a sustainable matter in the future */
 }
 
   /* full-width-modal remove once webuniversum updated */


### PR DESCRIPTION
There is a new besluittypes plugin. I used the old modal, which has some Z-index modal. We'll replace all plugins when the new appuniversum is in place in the next growth spurt. It would be good to create a sustainable z-index approach here in the meantime.

To test everything, edl these two plugins into [https://github.com/lblod/frontend-gelinkt-notuleren](https://github.com/lblod/frontend-gelinkt-notuleren)
- [https://github.com/lblod/ember-rdfa-editor-besluit-type-plugin](https://github.com/lblod/ember-rdfa-editor-besluit-type-plugin)
- [https://github.com/lblod/ember-vo-webuniversum](https://github.com/lblod/ember-vo-webuniversum)